### PR TITLE
Add support for encrypted URLs in profile

### DIFF
--- a/lib/Scheduler.js
+++ b/lib/Scheduler.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const config = require(__dirname + '/../config')
-const ErrorHandler = require('./lib/ErrorHandler')
+const ErrorHandler = require(__dirname + '/ErrorHandler')
 const SpeedTracker = require(__dirname + '/SpeedTracker')
 
 const Scheduler = function (options) {

--- a/lib/SpeedTracker.js
+++ b/lib/SpeedTracker.js
@@ -316,9 +316,11 @@ SpeedTracker.prototype.runTest = function (profile, isScheduled) {
     if (!parameters.url) return Promise.reject('NO_URL')
 
     let url = parameters.url.trim()
+
     if (!url.startsWith('http')) {
       url = Utils.decrypt(parameters.url, this.options.key)
     }
+
     delete parameters.url
 
     return this.options.scheduler.find(profileData._nwo, profileData._id).then(schedule => {


### PR DESCRIPTION
Currently, URLs in profiles are stored in plain text. This PR adds support for encrypted URLs, which can be generated using the [encrypt tool](https://speedtracker.org) just like every other encrypted field.

*Example:*

```yml
#
# WebPageTest test parameters
#
parameters:
  connectivity: "Cable"
  runs: 1
  url: "1317d7b95bd841d3b3c69e8e0e51c89d79534f4ced84"
```

Many thanks to @Spunkie for making this happen (original PR: #23).